### PR TITLE
Fix @types/react-dom resolution to an existing version

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,6 @@
   "resolutions": {
     "styletron-standard": "3.1.0",
     "@types/react": "18.3.24",
-    "@types/react-dom": "18.3.24"
+    "@types/react-dom": "18.3.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,7 +1918,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.15.0.tgz#963ab61779843fe910639a50661b48f162bc7f79"
   integrity sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==
 
-"@types/react-dom@18.3.24", "@types/react-dom@^18.0.11":
+"@types/react-dom@18.3.7", "@types/react-dom@^18.0.11":
   version "18.3.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
   integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==


### PR DESCRIPTION
The `resolutions` field in `package.json` pinned `@types/react-dom` to `18.3.24`, which doesn't exist on npm. This caused `yarn install` to prompt the user to manually pick a version.

Changed the resolution to `18.3.7`, the latest available v18 release, matching our `react-dom@18.3.1` runtime.